### PR TITLE
Made the Explore page dynamic

### DIFF
--- a/src/components/Animations/DisplaycardSkeleton.jsx
+++ b/src/components/Animations/DisplaycardSkeleton.jsx
@@ -1,0 +1,35 @@
+
+import React from "react";
+
+const DisplaycardSkeleton = () => {
+  return (
+    <div className="nft__item">
+      <div className="author_list_pp">
+        <div className="skeleton skeleton-author" />
+      </div>
+
+      <div className="de_countdown">
+        <div className="skeleton skeleton-countdown" />
+      </div>
+
+      <div className="nft__item_wrap">
+        <div className="nft__item_extra">
+          <div className="nft__item_buttons">
+            <div className="skeleton skeleton-button" />
+          </div>
+        </div>
+        <div className="skeleton skeleton-image" />
+      </div>
+
+      <div className="nft__item_info">
+        <div className="skeleton skeleton-title" />
+        <div className="skeleton skeleton-price" />
+        <div className="skeleton-likes-wrapper">
+          <div className="skeleton skeleton-likes" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DisplaycardSkeleton;

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,78 +1,143 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import axios from "axios";
 import AuthorImage from "../../images/author_thumbnail.jpg";
 import nftImage from "../../images/nftImage.jpg";
+import Countdown from "../Animations/Countdown";
+import DisplaycardSkeleton from "../Animations/DisplaycardSkeleton";
 
 const ExploreItems = () => {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [visibleCount, setVisibleCount] = useState(8);
+
+  const fetchItems = async (filterValue = "") => {
+    setLoading(true);
+    try {
+      const url = `https://us-central1-nft-cloud-functions.cloudfunctions.net/explore${
+        filterValue ? `?filter=${filterValue}` : ""
+      }`;
+      const response = await axios.get(url);
+      setItems(response.data);
+      setVisibleCount(8);
+    } catch (error) {
+      console.error("Failed to fetch data...", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchItems(filter);
+  }, [filter]);
+
+  const handleFilterChange = (e) => {
+    setFilter(e.target.value);
+  };
+
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => prev + 4)
+  }
+
   return (
     <>
-      <div>
-        <select id="filter-items" defaultValue="">
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <select id="filter-items" value={filter} onChange={handleFilterChange}>
           <option value="">Default</option>
           <option value="price_low_to_high">Price, Low to High</option>
           <option value="price_high_to_low">Price, High to Low</option>
           <option value="likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
-            </div>
-            <div className="de_countdown">5h 30m 32s</div>
 
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
+      {loading
+        ? new Array(8).fill(0).map((_, index) => (
+            <div
+              key={index}
+              className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+              style={{ display: "block", backgroundSize: "cover" }}
+            >
+              <DisplaycardSkeleton />
+            </div>
+          ))
+        : items.slice(0, visibleCount).map((item, index) => (
+            <div
+              key={index}
+              className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+              style={{ display: "block", backgroundSize: "cover" }}
+            >
+              <div className="nft__item">
+                <div className="author_list_pp">
+                  <Link to={`/author/${item.authorId}`}>
+                    <img
+                      className="lazy"
+                      src={item.authorImage || AuthorImage}
+                      alt=""
+                    />
+                    <i className="fa fa-check"></i>
+                  </Link>
+                </div>
+
+                {item.expiryDate && (
+                  <div className="de_countdown">
+                    <Countdown expiryDate={item.expiryDate} />
+                  </div>
+                )}
+
+                <div className="nft__item_wrap">
+                  <div className="nft__item_extra">
+                    <div className="nft__item_buttons">
+                      <button>Buy Now</button>
+                      <div className="nft__item_share">
+                        <h4>Share</h4>
+                        <a href="#">
+                          <i className="fa fa-facebook fa-lg"></i>
+                        </a>
+                        <a href="#">
+                          <i className="fa fa-twitter fa-lg"></i>
+                        </a>
+                        <a href="#">
+                          <i className="fa fa-envelope fa-lg"></i>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+
+                  <Link to={`/item-detail/${item.nftId}`}>
+                    <img
+                      src={item.nftImage || nftImage}
+                      className="lazy nft__item_preview"
+                      alt=""
+                    />
+                  </Link>
+                </div>
+
+                <div className="nft__item_info">
+                  <Link to={`/item-detail/${item.nftId}`}>
+                    <h4>{item.title}</h4>
+                  </Link>
+                  <div className="nft__item_price">{item.price} ETH</div>
+                  <div className="nft__item_like">
+                    <i className="fa fa-heart"></i>
+                    <span>{item.likes}</span>
                   </div>
                 </div>
               </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
             </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
-          </div>
+          ))}
+
+      {!loading && visibleCount < items.length && (
+        <div className="col-md-12 text-center">
+          <button
+          onClick={handleLoadMore}
+          id="loadmore"
+          className="btn-main lead"
+          >
+            Load more
+          </button>
         </div>
-      ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
-      </div>
+      )}
     </>
   );
 };

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -7,6 +7,7 @@ import Slider from "react-slick";
 import sliderSettings from "../Animations/slider";
 import "../../css/styles/skeleton.css";
 import Countdown from "../Animations/Countdown";
+import DisplaycardSkeleton from "../Animations/DisplaycardSkeleton";
 
 const NewItems = () => {
   const [collections, setNewDataCollections] = useState([]);
@@ -41,16 +42,14 @@ const NewItems = () => {
         <Slider {...sliderSettings}>
           {(loading ? Array(4).fill({}) : collections).map((item, index) => (
             <div key={index}>
-              <div className="nft__item">
-                <div className="author_list_pp">
-                  {loading ? (
-                    <div className="skeleton skeleton-author" />
-                  ) : (
+              {loading ? (
+                <DisplaycardSkeleton />
+              ) : (
+                <div className="nft__item">
+                  <div className="author_list_pp">
                     <Link
                       to={`/author/${item.authorId}`}
-                      data-bs-toggle="tooltip"
-                      data-bs-placement="top"
-                      title="Creator: Monica Lucas"
+                      title={`Creator: ${item.authorName}`}
                     >
                       <img
                         className="lazy"
@@ -59,35 +58,21 @@ const NewItems = () => {
                       />
                       <i className="fa fa-check"></i>
                     </Link>
-                  )}
-                </div>
-
-                {loading ? (
-                  <div className="de_countdown">
-                    <div className="skeleton skeleton-countdown" />
                   </div>
-                ) : (
-                  item.expiryDate && (
+
+                  {item.expiryDate && (
                     <div className="de_countdown">
                       <Countdown expiryDate={item.expiryDate} />
                     </div>
-                  )
-                )}
+                  )}
 
-                <div className="nft__item_wrap">
-                  <div className="nft__item_extra">
-                    <div className="nft__item_buttons">
-                      {loading ? (
-                        <div className="skeleton skeleton-button" />
-                      ) : (
+                  <div className="nft__item_wrap">
+                    <div className="nft__item_extra">
+                      <div className="nft__item_buttons">
                         <button>Buy Now</button>
-                      )}
+                      </div>
                     </div>
-                  </div>
 
-                  {loading ? (
-                    <div className="skeleton skeleton-image" />
-                  ) : (
                     <Link to={`/item-detail/${item.nftId}`}>
                       <img
                         src={item.nftImage}
@@ -95,34 +80,22 @@ const NewItems = () => {
                         alt=""
                       />
                     </Link>
-                  )}
-                </div>
+                  </div>
 
-                <div className="nft__item_info">
-                  {loading ? (
-                    <>
-                      <div className="skeleton skeleton-title" />
-                      <div className="skeleton skeleton-price" />
-                      <div className="skeleton-likes-wrapper">
-                        <div className="skeleton skeleton-likes" />
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <Link to={`/item-detail/${item.nftId}`}>
-                        <h4>{item.title}</h4>
-                      </Link>
-                      <div className="nft__item_price">
-                        {item.price ? `${item.price} ETH` : "--"}
-                      </div>
-                      <div className="nft__item_like">
-                        <i className="fa fa-heart"></i>
-                        <span>{item.likes || 0}</span>
-                      </div>
-                    </>
-                  )}
+                  <div className="nft__item_info">
+                    <Link to={`/item-detail/${item.nftId}`}>
+                      <h4>{item.title}</h4>
+                    </Link>
+                    <div className="nft__item_price">
+                      {item.price ? `${item.price} ETH` : "--"}
+                    </div>
+                    <div className="nft__item_like">
+                      <i className="fa fa-heart"></i>
+                      <span>{item.likes || 0}</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           ))}
         </Slider>

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,7 +5,6 @@ import ExploreItems from "../components/explore/ExploreItems";
 const Explore = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
-    // does this work?
   }, []);
 
   return (


### PR DESCRIPTION
I made the "Explore" page dynamic by hitting a API using "Axios". The page is now fully dynamic with a working sort drop down box that allow the user to sort price from low to high, high to low and a couple of other ways they'd like. The API allows for the displaying of multiple different NFTs along with their pricing and how many likes they have. On mount the page will display a skeleton loading state like the one used in the "New Items" section because the display cards are similar in design. The page will also only display 8 for the NFT cards until the user hits the "Load more" button then the page will display 4 more NFT cards until all 16 of the NFT cards are displayed then the button will disappear indicating that there is no more NFT cards to be loaded.  
![Screenshot 2025-06-09 192704](https://github.com/user-attachments/assets/18295adc-45d6-4b3d-93c8-7104406d1bf7)
![Screenshot 2025-06-09 200719](https://github.com/user-attachments/assets/011d28a1-cfae-48e9-9eb2-18e8414c3f9b)
![Screenshot 2025-06-09 200738](https://github.com/user-attachments/assets/d6ee8e01-40d8-4501-862c-d837f324ed6a)
